### PR TITLE
Fix page function names

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,4 @@
-export default function Home() {
+export default function HomePage() {
   return (
     <div>
       <h1>Bem-vindo ao ECOTANKE</h1>


### PR DESCRIPTION
## Summary
- rename the default export in `app/page.js` to `HomePage`

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687658478f34832e8b672422a466f09e